### PR TITLE
Disable ads in account section

### DIFF
--- a/app/controllers/users_controller.php
+++ b/app/controllers/users_controller.php
@@ -89,6 +89,7 @@ class UsersController extends AppController {
 	}
 
 	public function account() {
+		Configure::write('Feature.adsense', false);
 		$this->layout = 'app';
 		if(!empty($this->data)) {
 			$this->data['User']['id'] = $this->Auth->user('id');


### PR DESCRIPTION
To not get an SSL warning on account page, turned off ads feature flag in the account controller action.
