### PR TITLE
Remove blog and status page links.

### DIFF
--- a/app/View/Elements/app/footer.ctp
+++ b/app/View/Elements/app/footer.ctp
@@ -1,8 +1,7 @@
 <?php
 	$footer_links = array(
 		__('Terms of Service') => '/terms',
-		__('Privacy Policy') => '/privacy',
-		__('Status') => 'http://status.boxmeupapp.com'
+		__('Privacy Policy') => '/privacy'
 	);
 	if (Configure::read('Feature.api')) {
 		$footer_links[__('API')] = '/developer';

--- a/app/View/Elements/footer.ctp
+++ b/app/View/Elements/footer.ctp
@@ -1,7 +1,5 @@
 <?php
 	$footer_links = array(
-		__('Status') => 'http://status.boxmeupapp.com',
-		__('Blog') => 'http://blog.boxmeupapp.com',
 		__('Terms of Service') => '/terms',
 		__('Privacy Policy') => '/privacy'
 	);

--- a/app/View/Elements/nav.ctp
+++ b/app/View/Elements/nav.ctp
@@ -18,9 +18,6 @@
 		</div>
 	</li>
 </ul>
-<?php 
+<?php
 	}
 ?>
-<ul class="nav navbar-nav navbar-right" style="margin-right: 20px;">
-	<li><?php echo $this->Html->link(__('Blog'), 'http://blog.boxmeupapp.com'); ?></li>
-</ul>


### PR DESCRIPTION
These aren't being maintained and will go away once on the new hosting
platform.