### PR TITLE
Adding docker push capability to successful travis builds.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,9 @@
-contrib
+vendor
 .bowerrc
 .gitignore
 .env
 .travis.yml
 bower.json
-composer.json
-composer.lock
 CONTRIBUTING.md
 gruntfile.js
 jshint.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 
 before_script:
-  - composer install --dev
   - npm install
 
 script: ./node_modules/.bin/grunt ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ after_success:
   - bower install
   - gem install compass
   - ./node_modules/.bin/grunt build
-  - docker build -t cjsaylor/boxmeup .
+  - docker build -q -t cjsaylor/boxmeup .
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker push cjsaylor/boxmeup

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,4 @@ before_script:
 
 script: ./node_modules/.bin/grunt ci
 
-after_success:
-  - npm i -g bower
-  - bower install
-  - gem install compass
-  - ./node_modules/.bin/grunt build
-  - docker build -q -t cjsaylor/boxmeup .
-  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker push cjsaylor/boxmeup
+after_success: ./contrib/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
-language: php
-sudo: false
-php:
-  - 5.5
+language: ruby
+sudo: required
+services:
+  - docker
 
 before_script:
   - composer install --dev
   - npm install
 
 script: ./node_modules/.bin/grunt ci
+
+after_success:
+  - npm i -g bower
+  - bower install
+  - gem install compass
+  - ./node_modules/.bin/grunt build
+  - docker build -t cjsaylor/boxmeup .
+  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  - docker push cjsaylor/boxmeup

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,28 @@ FROM php:5.6-apache
 COPY config/apache/000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY config/php/php.ini /usr/local/etc/php/
 
-RUN docker-php-ext-install \
-    pdo_mysql
+RUN docker-php-ext-install pdo_mysql \
+    && apt-get update && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng12-dev \
+        zlib1g-dev \
+        git \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd \
+    && docker-php-ext-install zip
 
 COPY . /var/www/html/
+
+RUN curl -sS https://getcomposer.org/installer | php && \
+    php composer.phar install
+
+RUN apt-get remove --purge -y \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng12-dev \
+    zlib1g-dev \
+    git
 
 RUN a2enmod rewrite
 

--- a/contrib/deploy.sh
+++ b/contrib/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ev
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+    npm i -g bower
+    bower install
+    gem install compass
+    ./node_modules/.bin/grunt build
+    docker build -q -t cjsaylor/boxmeup .
+    docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+    docker push cjsaylor/boxmeup
+fi

--- a/contrib/setup.sh
+++ b/contrib/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-cp contrib/pre-commit .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
+if [ -d .git ]; then
+    cp contrib/pre-commit .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+fi


### PR DESCRIPTION
This PR seeks to add automatic docker image build and push to dockerhub on successful build.

Yes, I know it looks weird changing language to ruby, but php support for travis's docker environment is lacking at the moment, and once there are phpunit tests to run, the docker build command will get moved up into the `before_script` section and the tests will execute again the docker image.